### PR TITLE
to_rec/2: Change spec return type to tuple()

### DIFF
--- a/src/etbx.erl
+++ b/src/etbx.erl
@@ -244,7 +244,7 @@ first(_) ->
     throw(badarg).
     
 %% @doc converts a property list into a record.
--spec to_rec(recspec(), proplist()) -> record().
+-spec to_rec(recspec(), proplist()) -> tuple().
 to_rec(RSpec, {L}) when is_list(L) ->
     to_rec(RSpec, L);
 to_rec({R, [_ | N], Spec}, P) when is_atom(R) and is_list(Spec) ->


### PR DESCRIPTION
Changed the spec of to_rec/2 to returning a tuple() instead of the unknown type record().

dialyzer was complaining
```
dialyzer: Analysis failed with error:
etbx.erl:247: Unable to find type record/0
```