### PR TITLE
Remove mod tuple from etbx.app.src

### DIFF
--- a/src/etbx.app.src
+++ b/src/etbx.app.src
@@ -8,7 +8,6 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, { etbx_app, []}},
   {env, []}
  ]}.
 


### PR DESCRIPTION
The mod key is not necessary for code libraries, also the
configured module 'etbx_app' does not exist.